### PR TITLE
Improve bank start address heuristic

### DIFF
--- a/src/da65ify.c
+++ b/src/da65ify.c
@@ -69,7 +69,8 @@ int writeBankInfo(const char *romfilepath, FILE *romfile, FILE *cdlfile, int ban
         if (cdl & 0b1100 && foundstartaddr == 0) {
             foundstartaddr = 1;
             int newbank = (cdl >> 2) & 0b11;
-            startaddr = 0x8000 + ((newbank - 1) * 0x2000);
+            // location in memory from cdl file, rounded down to the bank size
+            startaddr = (0x8000 + (newbank * 0x2000)) / (banksize * 0x1000) * (banksize * 0x1000);
         }
     }
 


### PR DESCRIPTION
The previous method of getting a bank's start address was producing incorrect results. For example, if FCEUX marked an address as being mapped to "bank 2" (0xC000 - 0xDFFF), the previous method would put that bank at 0xA000. This change fixes this calculation and makes sure that the bank start address matches the boundaries of the provided bank size.